### PR TITLE
Update main.sh for Chromium on Debian

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -175,7 +175,7 @@ _main() {
         options+=("Google Chrome: Remove settings")
     fi
     # Chromium without settings applied
-    if [ "$OS" = "Linux" ] && [ -x "$(command -v chromium-browser)" ]; then
+    if [ "$OS" = "Linux" ] && { [ -x "$(command -v chromium-browser)" ] || [ -x "$(command -v chromium)" ]; }; then
         options+=("Chromium: Update settings")
     fi
     # Chromium with settings already applied


### PR DESCRIPTION
With Chromium from the Debian distribution repositories, the binary is just called `chromium`.

The syntax with braces is posixly correct according to https://www.shellcheck.net/wiki/SC1028