### PR TITLE
remove GenerativeAI

### DIFF
--- a/firefox/firefox.mobileconfig
+++ b/firefox/firefox.mobileconfig
@@ -35,19 +35,6 @@
 				<key>Stories</key>
 				<false/>
 			</dict>
-			<key>GenerativeAI</key>
-			<dict>
-				<key>Enabled</key>
-				<false/>
-				<key>Chatbot</key>
-				<false/>
-				<key>LinkPreviews</key>
-				<false/>
-				<key>TabGroups</key>
-				<false/>
-				<key>Locked</key>
-				<true/>
-			</dict>
 			<key>AIControls</key>
 			<dict>
 				<key>Default</key>

--- a/firefox/install.reg
+++ b/firefox/install.reg
@@ -11,13 +11,6 @@ Windows Registry Editor Version 5.00
 "SponsoredTopSites"=dword:00000000
 "Stories"=dword:00000000
 
-[HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Mozilla\Firefox\GenerativeAI]
-"Enabled"=dword:00000000
-"Chatbot"=dword:00000000
-"LinkPreviews"=dword:00000000
-"TabGroups"=dword:00000000
-"Locked"=dword:00000001
-
 [HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Mozilla\Firefox\AIControls\Default]
 "Value"="blocked"
 "Locked"=dword:00000001

--- a/firefox/policies.json
+++ b/firefox/policies.json
@@ -8,13 +8,6 @@
       "SponsoredTopSites": false,
       "Stories": false
     },
-    "GenerativeAI": {
-      "Enabled": false,
-      "Chatbot": false,
-      "LinkPreviews": false,
-      "TabGroups": false,
-      "Locked": true
-    },
     "AIControls": {
       "Default": {
         "Value": "blocked",


### PR DESCRIPTION
AIControls wins over GenerativeAI. Since we use it, we should remove it:
sorry for German screenshot:
<img width="976" height="274" alt="grafik" src="https://github.com/user-attachments/assets/b1890970-6672-4f1a-bca3-850c47dcc2ec" />

Sadly this isn't documentated, but can be seen under `about:policies#errors`