### PR TITLE
adding Brave support

### DIFF
--- a/brave/README.md
+++ b/brave/README.md
@@ -1,0 +1,53 @@
+---
+layout: layout.njk
+title: Brave Browser configuration
+permalink: "brave/index.html"
+---
+
+Brave Browser features can be configured with group policies. This project uses Windows Registry settings on Windows, and a Profile Manager file on macOS.
+
+You can check which policies are applied in Brave Browser by navigating to the `brave://policy/` page.
+
+### Windows installation
+
+1. Open the [registry file for installation](https://raw.githubusercontent.com/corbindavenport/just-the-browser/main/brave/install.reg) and save it (`Ctrl+S`) anywhere on your computer.
+2. In the File Explorer, right-click the file and select Open with > Registry Editor.
+3. Follow the prompts to install the registry keys to the Windows Registry.
+5. Restart Brave.
+
+To remove the custom configuration, follow the same steps with the [registry file for uninstallation](https://raw.githubusercontent.com/corbindavenport/just-the-browser/main/brave/uninstall.reg). This will remove the modified registry keys from your system.
+
+### macOS installation
+
+1. Open the [configuration file](https://raw.githubusercontent.com/corbindavenport/just-the-browser/main/brave/brave.mobileconfig) and save it (`Command+S`) anywhere on your computer.
+2. In the Finder, open the configuration file you downloaded. You should see a prompt that the profile is ready for review.
+3. Open the System Settings application (Apple menu > System Settings) and navigate to General > Device Management. If you are on macOS 12 Monterey or an older version, the application is called System Preferences, and you need to open the Profiles section.
+4. Double-click on the 'Brave Browser settings' configuration, then click the Install button and follow the prompts.
+
+To remove the custom configuration, open the Device Management settings (or Profiles pane) again, select the 'Brave Browser settings' configuration, and then click the remove (-) button.
+
+### Browser settings
+
+These are the policy settings in the Just the Browser configuration file.
+
+| Feature | Information |
+| ------- | ----------- |
+| AIModeSettings | Turns off Google's AI Mode integrations in the address bar and the New Tab page search box. |
+| CreateThemesSettings | Turns off the ability to create custom themes and wallpapers with generative AI. |
+| GenAILocalFoundationalModelSettings | Prevents the local AI model from being downloaded. |
+| HelpMeWriteSettings | Turns off the Help Me Write feature powered by AI. |
+| HistorySearchSettings | Turns off AI History Search. |
+| TabCompareSettings | Turns off the AI-powered Tab Compare feature. |
+| BuiltInDnsClientEnabled | Forces Chrome to use the host operating system's DNS client instead of the built-in DNS client. This has no effect when using DNS-over-HTTPS. |
+| DefaultBrowserSettingEnabled | Prevents Chrome from checking if it's the default browser and showing notifications about it. |
+| DevToolsGenAiSettings | Turns off debugging in the Dev Tools powered by generative AI models. |
+| BraveWalletDisabled | Disables Wallet, web3, and decentralized DNS settings and functionality. |
+| BraveVPNDisabled |  |
+| BraveAIChatEnabled |  |
+| BraveNewsDisabled |  |
+| BraveP3AEnabled |  |
+| BraveStatsPingEnabled |  |
+
+### Documentation
+
+- [Brave Group policy list](https://support.brave.app/hc/en-us/articles/360039248271-Group-Policy)

--- a/brave/README.md
+++ b/brave/README.md
@@ -37,11 +37,13 @@ These are the policy settings in the Just the Browser configuration file.
 | DefaultBrowserSettingEnabled | Prevents Brave from checking if it's the default browser and showing notifications about it. |
 | DevToolsGenAiSettings | Turns off debugging in the Dev Tools powered by generative AI models. |
 | BraveWalletDisabled | Disables Wallet, web3, and decentralized DNS settings and functionality. |
-| BraveVPNDisabled |  |
 | BraveAIChatEnabled | Turns off the AI chat features. |
 | BraveNewsDisabled | Turns off suggested news articles from Brave. |
-| BraveP3AEnabled | Turns off [Privacy-Preserving Product Analytics](https://brave.com/blog/privacy-preserving-product-analytics-p3a/). |
-| BraveStatsPingEnabled | Prevents usage data from being sent to Brave. |
+| BraveP3AEnabled | Controls whether the browser sends anonymous usage data to Brave. |
+| BraveRewardsDisabled | Turns off the Brave Rewards program where users earn BAT tokens. |
+| BraveStatsPingEnabled | A lightweight signal used to count active daily/monthly users. Disabling this stops the browser from announcing its presence to Brave's update servers. |
+| BraveTalkDisabled | Disables prompts for [Brave Talk](https://support.brave.app/hc/en-us/articles/4409911973261-How-do-I-use-Brave-Talk) service. It can still be accessed from `talk.brave.com`. |
+| BraveWebDiscoveryEnabled | Prevents sending "some anonymous data about searches and web page visits made within the Brave Browser" [for Brave Search](https://support.brave.app/hc/en-us/articles/4409406835469-What-is-the-Web-Discovery-Project). |
 
 ### Documentation
 

--- a/brave/README.md
+++ b/brave/README.md
@@ -32,22 +32,19 @@ These are the policy settings in the Just the Browser configuration file.
 
 | Feature | Information |
 | ------- | ----------- |
-| AIModeSettings | Turns off Google's AI Mode integrations in the address bar and the New Tab page search box. |
-| CreateThemesSettings | Turns off the ability to create custom themes and wallpapers with generative AI. |
 | GenAILocalFoundationalModelSettings | Prevents the local AI model from being downloaded. |
-| HelpMeWriteSettings | Turns off the Help Me Write feature powered by AI. |
-| HistorySearchSettings | Turns off AI History Search. |
-| TabCompareSettings | Turns off the AI-powered Tab Compare feature. |
-| BuiltInDnsClientEnabled | Forces Chrome to use the host operating system's DNS client instead of the built-in DNS client. This has no effect when using DNS-over-HTTPS. |
-| DefaultBrowserSettingEnabled | Prevents Chrome from checking if it's the default browser and showing notifications about it. |
+| BuiltInDnsClientEnabled | Forces Brave to use the host operating system's DNS client instead of the built-in DNS client. This has no effect when using DNS-over-HTTPS. |
+| DefaultBrowserSettingEnabled | Prevents Brave from checking if it's the default browser and showing notifications about it. |
 | DevToolsGenAiSettings | Turns off debugging in the Dev Tools powered by generative AI models. |
 | BraveWalletDisabled | Disables Wallet, web3, and decentralized DNS settings and functionality. |
 | BraveVPNDisabled |  |
-| BraveAIChatEnabled |  |
-| BraveNewsDisabled |  |
-| BraveP3AEnabled |  |
-| BraveStatsPingEnabled |  |
+| BraveAIChatEnabled | Turns off the AI chat features. |
+| BraveNewsDisabled | Turns off suggested news articles from Brave. |
+| BraveP3AEnabled | Turns off [Privacy-Preserving Product Analytics](https://brave.com/blog/privacy-preserving-product-analytics-p3a/). |
+| BraveStatsPingEnabled | Prevents usage data from being sent to Brave. |
 
 ### Documentation
 
 - [Brave Group policy list](https://support.brave.app/hc/en-us/articles/360039248271-Group-Policy)
+- [Chrome Enterprise policy list](https://chromeenterprise.google/policies/)
+- [Chromium Documentation for Administrators](https://www.chromium.org/administrators/linux-quick-start/)

--- a/brave/brave.mobileconfig
+++ b/brave/brave.mobileconfig
@@ -18,10 +18,6 @@
 			<string>11100B41-35B2-4185-B8FD-89F6A9E073A3</string>
 			<key>PayloadVersion</key>
 			<true/>
-			<key>AIModeSettings</key>
-			<integer>1</integer>
-			<key>CreateThemesSettings</key>
-			<integer>2</integer>
 			<key>GenAILocalFoundationalModelSettings</key>
 			<integer>1</integer>
 			<key>BuiltInDnsClientEnabled</key>
@@ -41,6 +37,8 @@
 			<key>BraveStatsPingEnabled</key>
 			<false/>
 			<key>BraveWalletDisabled</key>
+			<true/>
+			<key>BraveTalkDisabled</key>
 			<true/>
 			<key>BraveWebDiscoveryEnabled</key>
 			<false/>

--- a/brave/brave.mobileconfig
+++ b/brave/brave.mobileconfig
@@ -24,12 +24,6 @@
 			<integer>2</integer>
 			<key>GenAILocalFoundationalModelSettings</key>
 			<integer>1</integer>
-			<key>HelpMeWriteSettings</key>
-			<integer>2</integer>
-			<key>HistorySearchSettings</key>
-			<integer>2</integer>
-			<key>TabCompareSettings</key>
-			<integer>2</integer>
 			<key>BuiltInDnsClientEnabled</key>
 			<false />
 			<key>DefaultBrowserSettingEnabled</key>

--- a/brave/brave.mobileconfig
+++ b/brave/brave.mobileconfig
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<!-- https://support.brave.app/hc/en-us/articles/360039248271-Group-Policy#:~:text=1%20%3D%20Disabled-,braveaichatenabled,-0%2C%201%20(default -->
+			<!-- Configuration definitions -->
+			<key>PayloadDisplayName</key>
+			<string>Brave Browser settings</string>
+			<key>PayloadIdentifier</key>
+			<string>com.justthebrowser.bravesettings</string>
+			<key>PayloadOrganization</key>
+			<string>justthebrowser.com</string>
+			<key>PayloadType</key>
+			<string>com.brave.Brave</string>
+			<key>PayloadUUID</key>
+			<string>57FA2AE2-E222-4E59-9892-88BA444C90EF</string>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+			<key>AIModeSettings</key>
+			<integer>1</integer>
+			<key>CreateThemesSettings</key>
+			<integer>2</integer>
+			<key>GenAILocalFoundationalModelSettings</key>
+			<integer>1</integer>
+			<key>HelpMeWriteSettings</key>
+			<integer>2</integer>
+			<key>HistorySearchSettings</key>
+			<integer>2</integer>
+			<key>TabCompareSettings</key>
+			<integer>2</integer>
+			<key>BuiltInDnsClientEnabled</key>
+			<false />
+			<key>DefaultBrowserSettingEnabled</key>
+			<false />
+			<key>DevToolsGenAiSettings</key>
+			<integer>2</integer>
+			<key>BraveAIChatEnabled</key>
+			<integer>0</integer>
+			<key>BraveNewsDisabled</key>
+			<integer>1</integer>
+			<key>BraveP3AEnabled</key>
+			<integer>0</integer>
+			<key>BraveRewardsDisabled</key>
+			<integer>1</integer>
+			<key>BraveStatsPingEnabled</key>
+			<integer>0</integer>
+			<key>BraveWalletDisabled</key>
+			<integer>1</integer>
+			<key>BraveWebDiscoveryEnabled</key>
+			<integer>0</integer>
+			<key>BuiltInDnsClientEnabled</key>
+			<integer>0</integer>
+		</dict>
+	</array>
+	<key>PayloadDisplayName</key>
+	<string>Brave Browser settings</string>
+	<key>PayloadIdentifier</key>
+	<string>com.justthebrowser.bravesettings</string>
+	<key>PayloadOrganization</key>
+	<string>justthebrowser.com</string>
+	<key>PayloadScope</key>
+	<string>User</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>DA9835FF-7CA5-4139-B525-E450A9B8D1A1</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>

--- a/brave/brave.mobileconfig
+++ b/brave/brave.mobileconfig
@@ -2,24 +2,9 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>PayloadDisplayName</key>
-	<string>Brave</string>
-	<key>PayloadIdentifier</key>
-	<string>com.justthebrowser.brave</string>
-	<key>PayloadOrganization</key>
-	<string>justthebrowser.com</string>
-	<key>PayloadRemovalDisallowed</key>
-	<false/>
-	<key>PayloadType</key>
-	<string>Configuration</string>
-	<key>PayloadUUID</key>
-	<string>011A297A-61C9-488B-8E81-0261031F8C83</string>
-	<key>PayloadVersion</key>
-	<integer>1</integer>
 	<key>PayloadContent</key>
 	<array>
 		<dict>
-			<!-- https://support.brave.app/hc/en-us/articles/360039248271-Group-Policy#:~:text=1%20%3D%20Disabled-,braveaichatenabled,-0%2C%201%20(default -->
 			<!-- Configuration definitions -->
 			<key>PayloadDisplayName</key>
 			<string>Brave Browser settings</string>
@@ -30,7 +15,7 @@
 			<key>PayloadType</key>
 			<string>com.brave.Browser</string>
 			<key>PayloadUUID</key>
-			<string>57FA2AE2-E222-4E59-9892-88BA444C90EF</string>
+			<string>11100B41-35B2-4185-B8FD-89F6A9E073A3</string>
 			<key>PayloadVersion</key>
 			<true/>
 			<key>AIModeSettings</key>
@@ -67,5 +52,19 @@
 			<false/>
 		</dict>
 	</array>
+	<key>PayloadDisplayName</key>
+	<string>Brave settings</string>
+	<key>PayloadIdentifier</key>
+	<string>com.justthebrowser.brave</string>
+	<key>PayloadOrganization</key>
+	<string>justthebrowser.com</string>
+	<key>PayloadScope</key>
+	<string>User</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>C6A03082-9813-4FB3-889A-23CE80877075</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
 </dict>
 </plist>

--- a/brave/brave.mobileconfig
+++ b/brave/brave.mobileconfig
@@ -2,6 +2,20 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>PayloadDisplayName</key>
+	<string>Brave</string>
+	<key>PayloadIdentifier</key>
+	<string>com.justthebrowser.brave</string>
+	<key>PayloadOrganization</key>
+	<string>justthebrowser.com</string>
+	<key>PayloadRemovalDisallowed</key>
+	<false/>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>011A297A-61C9-488B-8E81-0261031F8C83</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
 	<key>PayloadContent</key>
 	<array>
 		<dict>
@@ -14,11 +28,11 @@
 			<key>PayloadOrganization</key>
 			<string>justthebrowser.com</string>
 			<key>PayloadType</key>
-			<string>com.brave.Brave</string>
+			<string>com.brave.Browser</string>
 			<key>PayloadUUID</key>
 			<string>57FA2AE2-E222-4E59-9892-88BA444C90EF</string>
 			<key>PayloadVersion</key>
-			<integer>1</integer>
+			<true/>
 			<key>AIModeSettings</key>
 			<integer>1</integer>
 			<key>CreateThemesSettings</key>
@@ -38,36 +52,20 @@
 			<key>DevToolsGenAiSettings</key>
 			<integer>2</integer>
 			<key>BraveAIChatEnabled</key>
-			<integer>0</integer>
+			<false/>
 			<key>BraveNewsDisabled</key>
-			<integer>1</integer>
+			<true/>
 			<key>BraveP3AEnabled</key>
-			<integer>0</integer>
+			<false/>
 			<key>BraveRewardsDisabled</key>
-			<integer>1</integer>
+			<true/>
 			<key>BraveStatsPingEnabled</key>
-			<integer>0</integer>
+			<false/>
 			<key>BraveWalletDisabled</key>
-			<integer>1</integer>
+			<true/>
 			<key>BraveWebDiscoveryEnabled</key>
-			<integer>0</integer>
-			<key>BuiltInDnsClientEnabled</key>
-			<integer>0</integer>
+			<false/>
 		</dict>
 	</array>
-	<key>PayloadDisplayName</key>
-	<string>Brave Browser settings</string>
-	<key>PayloadIdentifier</key>
-	<string>com.justthebrowser.bravesettings</string>
-	<key>PayloadOrganization</key>
-	<string>justthebrowser.com</string>
-	<key>PayloadScope</key>
-	<string>User</string>
-	<key>PayloadType</key>
-	<string>Configuration</string>
-	<key>PayloadUUID</key>
-	<string>DA9835FF-7CA5-4139-B525-E450A9B8D1A1</string>
-	<key>PayloadVersion</key>
-	<integer>1</integer>
 </dict>
 </plist>

--- a/brave/install.reg
+++ b/brave/install.reg
@@ -15,7 +15,7 @@ Windows Registry Editor Version 5.00
 "BraveWebDiscoveryEnabled"=dword:00000000
 
 [HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Uninstall\JustTheBrowserBrave]
-"DisplayName"="Just the Browser configuration - Brave Browser
+"DisplayName"="Just the Browser configuration - Brave Browser"
 "URLInfoAbout"="https://justthebrowser.com/"
 "UninstallString"="powershell.exe -Command \"Remove-Item -Path HKLM:\\SOFTWARE\\Policies\\BraveSoftware\\Brave,HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\JustTheBrowserBrave -Recurse -ErrorAction SilentlyContinue\""
 "ModifyPath"="explorer.exe \"https://justthebrowser.com/\""

--- a/brave/install.reg
+++ b/brave/install.reg
@@ -15,7 +15,6 @@ Windows Registry Editor Version 5.00
 "BravePlaylistEnabled"=dword:00000000
 "BraveSpeedreaderEnabled"=dword:00000000
 "BraveTalkDisabled"=dword:00000001
-"BraveWaybackMachineEnabled"=dword:00000000
 
 [HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Uninstall\JustTheBrowserChrome]
 "DisplayName"="Just the Browser configuration - Brave Browser

--- a/brave/install.reg
+++ b/brave/install.reg
@@ -1,0 +1,24 @@
+Windows Registry Editor Version 5.00
+
+[HKEY_LOCAL_MACHINE\Software\Policies\BraveSoftware\Brave]
+"AIModeSettings"=dword:00000001
+"CreateThemesSettings"=dword:00000002
+"GenAILocalFoundationalModelSettings"=dword:00000001
+"HelpMeWriteSettings"=dword:00000002
+"HistorySearchSettings"=dword:00000002
+"TabCompareSettings"=dword:00000002
+"BuiltInDnsClientEnabled"=dword:00000000
+"DefaultBrowserSettingEnabled"=dword:00000000
+"DevToolsGenAiSettings"=dword:00000002
+"BraveAIChatEnabled"=dword:00000000
+"BraveNewsDisabled"=dword:00000001
+"BravePlaylistEnabled"=dword:00000000
+"BraveSpeedreaderEnabled"=dword:00000000
+"BraveTalkDisabled"=dword:00000001
+"BraveWaybackMachineEnabled"=dword:00000000
+
+[HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Uninstall\JustTheBrowserChrome]
+"DisplayName"="Just the Browser configuration - Brave Browser
+"URLInfoAbout"="https://justthebrowser.com/"
+"UninstallString"="powershell.exe -Command \"Remove-Item -Path HKLM:\\SOFTWARE\\Policies\\BraveSoftware\\Brave,HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\JustTheBrowserBrave -Recurse -ErrorAction SilentlyContinue\""
+"ModifyPath"="explorer.exe \"https://justthebrowser.com/\""

--- a/brave/install.reg
+++ b/brave/install.reg
@@ -1,12 +1,7 @@
 Windows Registry Editor Version 5.00
 
 [HKEY_LOCAL_MACHINE\Software\Policies\BraveSoftware\Brave]
-"AIModeSettings"=dword:00000001
-"CreateThemesSettings"=dword:00000002
 "GenAILocalFoundationalModelSettings"=dword:00000001
-"HelpMeWriteSettings"=dword:00000002
-"HistorySearchSettings"=dword:00000002
-"TabCompareSettings"=dword:00000002
 "BuiltInDnsClientEnabled"=dword:00000000
 "DefaultBrowserSettingEnabled"=dword:00000000
 "DevToolsGenAiSettings"=dword:00000002

--- a/brave/install.reg
+++ b/brave/install.reg
@@ -5,13 +5,16 @@ Windows Registry Editor Version 5.00
 "BuiltInDnsClientEnabled"=dword:00000000
 "DefaultBrowserSettingEnabled"=dword:00000000
 "DevToolsGenAiSettings"=dword:00000002
+"BraveWalletDisabled"=dword:00000001
+"BraveP3AEnabled"=dword:00000000
+"BraveRewardsDisabled"=dword:00000001
+"BraveStatsPingEnabled"=dword:00000000
 "BraveAIChatEnabled"=dword:00000000
 "BraveNewsDisabled"=dword:00000001
-"BravePlaylistEnabled"=dword:00000000
-"BraveSpeedreaderEnabled"=dword:00000000
 "BraveTalkDisabled"=dword:00000001
+"BraveWebDiscoveryEnabled"=dword:00000000
 
-[HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Uninstall\JustTheBrowserChrome]
+[HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Uninstall\JustTheBrowserBrave]
 "DisplayName"="Just the Browser configuration - Brave Browser
 "URLInfoAbout"="https://justthebrowser.com/"
 "UninstallString"="powershell.exe -Command \"Remove-Item -Path HKLM:\\SOFTWARE\\Policies\\BraveSoftware\\Brave,HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\JustTheBrowserBrave -Recurse -ErrorAction SilentlyContinue\""

--- a/brave/managed_policies.json
+++ b/brave/managed_policies.json
@@ -1,10 +1,5 @@
 {
-  "AIModeSettings": 1,
-  "CreateThemesSettings": 2,
   "GenAILocalFoundationalModelSettings": 1,
-  "HelpMeWriteSettings": 2,
-  "HistorySearchSettings": 2,
-  "TabCompareSettings": 2,
   "BuiltInDnsClientEnabled": false,
   "DefaultBrowserSettingEnabled": false,
   "DevToolsGenAiSettings": 2,

--- a/brave/managed_policies.json
+++ b/brave/managed_policies.json
@@ -1,0 +1,17 @@
+{
+  "AIModeSettings": 1,
+  "CreateThemesSettings": 2,
+  "GenAILocalFoundationalModelSettings": 1,
+  "HelpMeWriteSettings": 2,
+  "HistorySearchSettings": 2,
+  "TabCompareSettings": 2,
+  "BuiltInDnsClientEnabled": false,
+  "DefaultBrowserSettingEnabled": false,
+  "DevToolsGenAiSettings": 2,
+  "BraveAIChatEnabled" : 0,
+  "BraveNewsDisabled" : 1,
+  "BravePlaylistEnabled" : 0,
+  "BraveSpeedreaderEnabled" : 0,
+  "BraveTalkDisabled" : 1,
+  "BraveWaybackMachineEnabled" : 0
+}

--- a/brave/managed_policies.json
+++ b/brave/managed_policies.json
@@ -3,9 +3,12 @@
   "BuiltInDnsClientEnabled": false,
   "DefaultBrowserSettingEnabled": false,
   "DevToolsGenAiSettings": 2,
+  "BraveWalletDisabled": true,
+  "BraveP3AEnabled": false,
+  "BraveRewardsDisabled": true,
+  "BraveStatsPingEnabled": false,
   "BraveAIChatEnabled" : false,
   "BraveNewsDisabled" : true,
-  "BravePlaylistEnabled" : false,
-  "BraveSpeedreaderEnabled" : false,
-  "BraveTalkDisabled" : true
+  "BraveTalkDisabled" : true,
+  "BraveWebDiscoveryEnabled": false
 }

--- a/brave/managed_policies.json
+++ b/brave/managed_policies.json
@@ -8,10 +8,9 @@
   "BuiltInDnsClientEnabled": false,
   "DefaultBrowserSettingEnabled": false,
   "DevToolsGenAiSettings": 2,
-  "BraveAIChatEnabled" : 0,
-  "BraveNewsDisabled" : 1,
-  "BravePlaylistEnabled" : 0,
-  "BraveSpeedreaderEnabled" : 0,
-  "BraveTalkDisabled" : 1,
-  "BraveWaybackMachineEnabled" : 0
+  "BraveAIChatEnabled" : false,
+  "BraveNewsDisabled" : true,
+  "BravePlaylistEnabled" : false,
+  "BraveSpeedreaderEnabled" : false,
+  "BraveTalkDisabled" : true
 }

--- a/brave/uninstall.reg
+++ b/brave/uninstall.reg
@@ -1,0 +1,3 @@
+Windows Registry Editor Version 5.00
+
+[-HKEY_LOCAL_MACHINE\Software\Policies\BraveSoftware\Brave]

--- a/brave/uninstall.reg
+++ b/brave/uninstall.reg
@@ -1,3 +1,5 @@
 Windows Registry Editor Version 5.00
 
 [-HKEY_LOCAL_MACHINE\Software\Policies\BraveSoftware\Brave]
+
+[-HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\JustTheBrowserBrave]

--- a/index.md
+++ b/index.md
@@ -12,7 +12,7 @@ This project includes configuration files for popular web browsers, documentatio
 
 ## Get started
 
-The setup script can install the configuration files in a few clicks. You can also follow the manual guides for [Google Chrome](/chrome), [Microsoft Edge](/edge), and [Firefox](/firefox). If you don't like running scripts with administrator/root access, or the script does not work, use the guides instead.
+The setup script can install the configuration files in a few clicks. You can also follow the manual guides for [Google Chrome](/chrome), [Microsoft Edge](/edge), [Firefox](/firefox), and [Brave](/brave). If you don't like running scripts with administrator/root access, or the script does not work, use the guides instead.
 
 **Windows:** Search for "Windows PowerShell" in the Start Menu, right-click it, and select the "Run as administrator" option. Next, copy the below command, paste it into the window (`Ctrl+V`), and press the Enter/Return key:
 ```
@@ -72,6 +72,10 @@ Not sure which link to use? Try the [official download page](https://www.firefox
 
 Not sure which link to use? Try the [official download page](https://www.microsoft.com/en-us/edge/download).
 
+### Brave Browser
+
+[Latest version from GitHub](https://github.com/brave/brave-browser/releases/latest)
+
 ## Questions and answers
 
 Got a question? Check here first, and if you still need help, [create an issue on GitHub](https://github.com/corbindavenport/just-the-browser/issues) or [join the Discord](https://discord.com/invite/tqJDRsmQVn).
@@ -88,7 +92,7 @@ Just the Browser aims to remove the following functionality from popular web bro
 - **Telemetry:** Data collection by web browsers. Crash reporting is left enabled if the browser (such as Firefox) supports it as a separate option.
 - **Startup boost:** Features that allow web browsers to start with the operating system without explicit permission.
 
-The exact list of features modified for each browser can be found on the pages for [Google Chrome](/chrome), [Microsoft Edge](/edge), and [Firefox](/firefox).
+The exact list of features modified for each browser can be found on the pages for [Google Chrome](/chrome), [Microsoft Edge](/edge), [Firefox](/firefox), and [Brave](/brave).
 
 ### Can I change or remove the settings?
 
@@ -96,11 +100,11 @@ Yes. The browser guides include steps for removing the configurations, and the a
 
 ### How do I know the settings are applied?
 
-You can open `about:policies` in Firefox or `chrome://policy` in Chrome and Edge to see a list of active group policy settings.
+You can open `about:policies` in Firefox or `chrome://policy` in Chrome, Edge, and Brave to see a list of active group policy settings.
 
 ### Which web browsers are supported?
 
-Just the Browser has configuration files and setup scripts for Google Chrome, Microsoft Edge, and Mozilla Firefox. Chromium builds on Linux are also supported. [Edge on Linux](https://github.com/corbindavenport/just-the-browser/issues/1) is not currently supported.
+Just the Browser has configuration files and setup scripts for Google Chrome, Microsoft Edge, Mozilla Firefox, and Brave. Chromium builds on Linux are also supported. [Edge on Linux](https://github.com/corbindavenport/just-the-browser/issues/1) is not currently supported.
 
 ### Which operating systems are supported?
 
@@ -130,7 +134,7 @@ No. If you want one, try [uBlock Origin](https://github.com/gorhill/uBlock) or [
 
 ### Does this disable DNS-over-HTTPS?
 
-Google Chrome and Microsoft Edge will use the operating system's DNS client for regular DNS queries, and DNS-over-HTTPS is disabled. DNS-over-HTTPS can [improve privacy and security in some situations](https://heimdalsecurity.com/blog/dns-over-https-doh/), but when a custom configuration like Just the Browser is enabled, Chrome and Edge block access to the DNS options in the browser. Rather than switch DNS-over-HTTPS back to automatic or always-on mode, this project leaves it disabled.
+Google Chrome, Microsoft Edge, and Brave will use the operating system's DNS client for regular DNS queries, and DNS-over-HTTPS is disabled. DNS-over-HTTPS can [improve privacy and security in some situations](https://heimdalsecurity.com/blog/dns-over-https-doh/), but when a custom configuration like Just the Browser is enabled, Chrome/Edge/Brave will block access to the DNS options in the browser. Rather than switch DNS-over-HTTPS back to automatic or always-on mode, this project leaves it disabled.
 
 No DNS settings are changed for Firefox. You can access those options in `about:preferences#privacy` if needed. 
 

--- a/main.ps1
+++ b/main.ps1
@@ -5,8 +5,7 @@
 [Net.ServicePointManager]::SecurityProtocol=[Net.SecurityProtocolType]::Tls12
 
 $OS = Get-CimInstance Win32_OperatingSystem
-# $BaseURL = "https://raw.githubusercontent.com/corbindavenport/just-the-browser/main/"
-$BaseURL = "https://kalak.fun/jtb/"
+$BaseURL = "https://raw.githubusercontent.com/corbindavenport/just-the-browser/main/"
 $MicrosoftEdgeInstallRegistry = "$BaseURL/edge/install.reg"
 $MicrosoftEdgeUninstallRegistry = "$BaseURL/edge/uninstall.reg"
 $GoogleChromeInstallRegistry = "$BaseURL/chrome/install.reg"

--- a/main.ps1
+++ b/main.ps1
@@ -5,13 +5,16 @@
 [Net.ServicePointManager]::SecurityProtocol=[Net.SecurityProtocolType]::Tls12
 
 $OS = Get-CimInstance Win32_OperatingSystem
-$BaseURL = "https://raw.githubusercontent.com/corbindavenport/just-the-browser/main/"
+# $BaseURL = "https://raw.githubusercontent.com/corbindavenport/just-the-browser/main/"
+$BaseURL = "https://kalak.fun/jtb/"
 $MicrosoftEdgeInstallRegistry = "$BaseURL/edge/install.reg"
 $MicrosoftEdgeUninstallRegistry = "$BaseURL/edge/uninstall.reg"
 $GoogleChromeInstallRegistry = "$BaseURL/chrome/install.reg"
 $GoogleChromeUninstallRegistry = "$BaseURL/chrome/uninstall.reg"
 $FirefoxInstallRegistry = "$BaseURL/firefox/install.reg"
 $FirefoxUninstallRegistry = "$BaseURL/firefox/uninstall.reg"
+$BraveInstallRegistry = "$BaseURL/brave/install.reg"
+$BraveUninstallRegistry = "$BaseURL/brave/uninstall.reg"
 
 # Render initial interface for all pages
 function Show-Header {
@@ -120,6 +123,50 @@ function Uninstall-Edge {
     }
 }
 
+# Install Brave settings
+function Install-Brave {
+    Show-Header
+    Write-Host "Downloading registry file, please wait..."
+    # Download file
+    try {
+        Invoke-WebRequest $BraveInstallRegistry -OutFile "$env:LocalAppData\brave.reg"
+    }
+    catch {
+        Read-Host -Prompt "Download failed! Press Enter/Return to continue" | Out-Null
+        Return
+    }
+    # Install file
+    $BraveInstall = Start-Process "reg.exe" -ArgumentList "import `"$env:LocalAppData\brave.reg`"" -WindowStyle Hidden -Wait -PassThru
+    if ($BraveInstall.ExitCode -eq 0) {
+        Read-Host -Prompt "Updated Brave settings. Press Enter/Return to continue" | Out-Null
+    }
+    else {
+        Read-Host -Prompt "Install failed! Press Enter/Return to continue" | Out-Null
+    }
+}
+
+# Remove Brave settings
+function Uninstall-Brave {
+    Show-Header
+    Write-Host "Downloading registry file, please wait..."
+    # Download file
+    try {
+        Invoke-WebRequest $BraveUninstallRegistry -OutFile "$env:LocalAppData\brave.reg"
+    }
+    catch {
+        Read-Host -Prompt "Download failed! Press Enter/Return to continue" | Out-Null
+        Return
+    }
+    # Install file
+    $BraveUninstall = Start-Process "reg.exe" -ArgumentList "import `"$env:LocalAppData\brave.reg`"" -WindowStyle Hidden -Wait -PassThru
+    if ($BraveUninstall.ExitCode -eq 0) {
+        Read-Host -Prompt "Removed Brave settings. Press Enter/Return to continue" | Out-Null
+    }
+    else {
+        Read-Host -Prompt "Remove failed! Press Enter/Return to continue" | Out-Null
+    }
+}
+
 # Install Firefox settings
 function Install-Firefox {
     Param(
@@ -179,6 +226,7 @@ function Uninstall-Firefox {
     }
 }
 
+
 # Main menu selection
 function Show-Menu {
     # Create list for menu options
@@ -210,6 +258,21 @@ function Show-Menu {
             $options.Add(@{
                     Label  = "Microsoft Edge: Remove settings"
                     Action = { Uninstall-Edge }
+                })
+        }
+    }
+    # Brave without settings applied
+    $options.Add(@{
+            Label  = "Brave: Update settings"
+            Action = { Install-Brave }
+        })
+    # Brave with settings applied
+    if (Test-Path "HKLM:\SOFTWARE\Policies\BraveSoftware\Brave") {
+        $BraveCheck = (Get-ItemProperty -Path "HKLM:\SOFTWARE\Policies\BraveSoftware\Brave" -ErrorAction SilentlyContinue).WaitForBrowserInit
+        if ($null -ne $BraveCheck) {
+            $options.Add(@{
+                    Label  = "Brave: Remove settings"
+                    Action = { Uninstall-Brave }
                 })
         }
     }

--- a/main.sh
+++ b/main.sh
@@ -1,12 +1,15 @@
 #!/bin/bash
 
 OS=$(uname)
-BASEURL="https://raw.githubusercontent.com/corbindavenport/just-the-browser/main"
+# BASEURL="https://raw.githubusercontent.com/corbindavenport/just-the-browser/main"
+BASEURL="https://kalak.fun/jtb/"
 MICROSOFT_EDGE_MAC_CONFIG="$BASEURL/edge/edge.mobileconfig"
 GOOGLE_CHROME_MAC_CONFIG="$BASEURL/chrome/chrome.mobileconfig"
 FIREFOX_MAC_CONFIG="$BASEURL/firefox/firefox.mobileconfig"
 FIREFOX_SETTINGS="$BASEURL/firefox/policies.json"
 CHROME_SETTINGS="$BASEURL/chrome/managed_policies.json"
+BRAVE_SETTINGS="$BASEURL/brave/managed_policies.json"
+BRAVE_MAC_CONFIG="$BASEURL/brave/brave.mobileconfig"
 
 # Generate a temporary directory on macOS instead of broken default $TMPDIR
 if [ "$OS" = "Darwin" ]; then
@@ -208,6 +211,40 @@ _uninstall_firefox_flatpak() {
     read -p "Removed Firefox settings. Press Enter/Return to continue."
 }
 
+# Install Brave settings
+_install_brave() {
+    _show_header
+    echo "Downloading configuration, please wait..."
+    if [ "$OS" = "Darwin" ]; then
+        # Download and open configuration file
+        curl -Lfs -o "$TMPDIR/brave.mobileconfig" "$BRAVE_MAC_CONFIG" || { read -p "Download failed! Press Enter/Return to continue."; return; }
+        open "$TMPDIR/brave.mobileconfig"
+        open -b "com.apple.systempreferences"
+        # Prompt user to accept file
+        echo -e "\nIn the System Settings application, navigate to General > Device Management, then open Brave settings and click the Install button.\n\nIn older macOS versions with System Preferences, this is in the Profiles section.\n"
+        read -p "Press Enter/Return to continue."
+    else
+        _confirm_root
+        "${AS_ROOT}" mkdir -p "/etc/brave/policies/managed"
+        "${AS_ROOT}" curl -Lfs -o "/etc/brave/policies/managed/managed_policies.json" "$BRAVE_SETTINGS" || { read -p "Download failed! Press Enter/Return to continue."; return; }
+        read -p "Installed Brave settings. Press Enter/Return to continue."
+    fi
+}
+
+# Remove Brave settings
+_uninstall_brave() {
+    _show_header
+    if [ "$OS" = "Darwin" ]; then
+        open -b "com.apple.systempreferences"
+        echo -e "\nIn the System Settings application, navigate to General > Device Management, then select 'Brave settings' and click the remove (-) button.\n\nIn older macOS versions with System Preferences, this is in the Profiles section.\n"
+        read -p "Press Enter/Return to continue."
+    else
+        _confirm_root
+        "${AS_ROOT}" rm "/etc/brave/policies/managed/managed_policies.json" || { read -p "Remove failed! Press Enter/Return to continue."; return; }
+        read -p "Removed Brave settings. Press Enter/Return to continue."
+    fi
+}
+
 # Main menu selection
 _main() {
     # Create list for menu options
@@ -261,6 +298,18 @@ _main() {
         options+=("Firefox Flatpak: Update settings")
         options+=("Firefox Flatpak: Remove settings")
     fi
+    # Brave without settings applied
+    if [ "$OS" = "Darwin" ]; then
+        options+=("Brave: Update settings")
+    elif [ "$OS" = "Linux" ] && [ -x "$(command -v brave-browser)" ]; then
+        options+=("Brave: Update settings")
+    fi
+    # Brave with settings already applied
+    if [ "$OS" = "Darwin" ]; then
+        options+=("Brave: Remove settings")
+    elif [ "$OS" = "Linux" ] && [ -e "/etc/brave/policies/managed/managed_policies.json" ]; then
+        options+=("Brave: Remove settings")
+    fi
     # Add exit option
     options+=("Exit")
     # Show main menu
@@ -291,6 +340,10 @@ _main() {
             _install_firefox_flatpak
         elif [ "$choice" = "Firefox Flatpak: Remove settings" ]; then
             _uninstall_firefox_flatpak
+        elif [ "$choice" = "Brave: Update settings" ]; then
+            _install_brave
+        elif [ "$choice" = "Brave: Remove settings" ]; then
+            _uninstall_brave
         elif [ "$choice" = "Exit" ]; then
             exit 0
         else

--- a/main.sh
+++ b/main.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
 OS=$(uname)
-# BASEURL="https://raw.githubusercontent.com/corbindavenport/just-the-browser/main"
-BASEURL="https://kalak.fun/jtb/"
+BASEURL="https://raw.githubusercontent.com/corbindavenport/just-the-browser/main"
 MICROSOFT_EDGE_MAC_CONFIG="$BASEURL/edge/edge.mobileconfig"
 GOOGLE_CHROME_MAC_CONFIG="$BASEURL/chrome/chrome.mobileconfig"
 FIREFOX_MAC_CONFIG="$BASEURL/firefox/firefox.mobileconfig"


### PR DESCRIPTION
Fixes #17 This adds the necessary files for Brave support. I've based this off the Chrome files and added policies based on [Brave's policy documentation](https://support.brave.app/hc/en-us/articles/360039248271-Group-Policy).

I've tested this on macOS 26.5.1 Tahoe, Windows 10 22H2, Fedora 43.